### PR TITLE
Use new user registration scheme

### DIFF
--- a/resources/lib/tools.py
+++ b/resources/lib/tools.py
@@ -36,9 +36,8 @@ def get_version():
     return "unknown"
 
 def register_user(hue_ip):
-  username = hashlib.md5(str(random.random())).hexdigest()
-  device = "xbmc-player"
-  data = '{"username": "%s", "devicetype": "%s"}' % (username, device)
+  device = "kodi#ambilight"
+  data = '{"devicetype": "%s"}' % device
 
   r = requests.post('http://%s/api' % hue_ip, data=data)
   response = r.text
@@ -48,7 +47,7 @@ def register_user(hue_ip):
     response = r.text 
     time.sleep(3)
 
-  return username
+  return r.json()[0]['success']['username']
 
 class Light:
   start_setting = None


### PR DESCRIPTION
Sending the user name in the registration request is deprecated and raises an error. The new scheme is to skip the user name in the request, let the bridge generate one and then use this one.
